### PR TITLE
Added Direct Moonboot contract as milestone and showed it on the timeline

### DIFF
--- a/RP1AnalyticsWebApp/Configs/milestoneContracts.json
+++ b/RP1AnalyticsWebApp/Configs/milestoneContracts.json
@@ -34,6 +34,7 @@
   "first_MoonFlybyCrewed",
   "FirstCrewedLunarOrbit",
   "first_MoonLandingCrewed",
+  "first_MoonLandingCrewedDirect",
   "flybyMercury",
   "flybyVenus",
   "flybyMars",

--- a/RP1AnalyticsWebApp/src/components/Chart.vue
+++ b/RP1AnalyticsWebApp/src/components/Chart.vue
@@ -32,6 +32,7 @@
         ['LunarImpactor', 'Lunar Impactor'],
         ['first_OrbitCrewed', 'Crewed Orbit'],
         ['first_MoonLandingCrewed', 'Crewed Moon'],
+        ['first_MoonLandingCrewedDirect', 'Crewed Moon (Direct)'],
         ['MarsLandingCrew', 'Crewed Mars'],
         ['first_spaceStation', 'Space Station']
     ]));


### PR DESCRIPTION
We realized Direct Moonboot was not showing on the timeline during RiS, and was missing from the milestone list. 