### PR TITLE
Rename life support nodes to be less confusing for users and developers

### DIFF
--- a/RP1AnalyticsWebApp/Configs/techTree.json
+++ b/RP1AnalyticsWebApp/Configs/techTree.json
@@ -732,20 +732,20 @@
     "Title": "Crew Survivability"
   },
   {
-    "ID": "earlyLifeSupport",
-    "Title": "Early Life Support and ISRU"
+    "ID": "rudimentaryLifeSupport",
+    "Title": "Rudimentary Life Support"
   },
   {
-    "ID": "lifeSupportISRU",
-    "Title": "Life Support and ISRU"
+    "ID": "earlyLifeSupport",
+    "Title": "Early Life Support"
   },
   {
     "ID": "basicLifeSupport",
-    "Title": "Basic Life Support and ISRU"
+    "Title": "Basic Life Support"
   },
   {
     "ID": "improvedLifeSupport",
-    "Title": "Improved Life Support and ISRU"
+    "Title": "Improved Life Support"
   },
   {
     "ID": "longTermLifeSupport",


### PR DESCRIPTION
Fix https://github.com/KSP-RO/RP-1/issues/2491

Rename:
```
titles:
Early Life Support and ISRU
Life Support and ISRU
Basic Life Support and ISRU
Improved Lift Support and ISRU

ids:
earlyLifeSupport
lifeSupportISRU
basicLifeSupport
improvedLifeSupport
```

to:
```
titles:
Rudimentary Life Support
Early Life Support
Basic Life Support
Improved Life Support

ids:
rudimentaryLifeSupport
earlyLifeSupport
basicLifeSupport
improvedLifeSupport
```

Relevant:
https://github.com/KSP-RO/RP-1/pull/2500
https://github.com/KSP-RO/ROKerbalism/pull/175